### PR TITLE
Modify Helm charts to support import of customer API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation via [helm](https://helm.sh/docs/intro/install/) can be achieved in 
 
 #### Local Checkout
 ```sh
-git clone git@bits.linode.com:hwagner/cloud-firewall-controller.git
+git clone git@bits.linode.com:linode/cloud-firewall-controller.git
 cd cloud-firewall-controller 
 # (optional) git checkout <tag> 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation via [helm](https://helm.sh/docs/intro/install/) can be achieved in 
 
 #### Local Checkout
 ```sh
-git clone git@bits.linode.com:linode/cloud-firewall-controller.git
+git clone git@github.com:linode/cloud-firewall-controller.git
 cd cloud-firewall-controller 
 # (optional) git checkout <tag> 
 

--- a/helm/controller/templates/deployment.yaml
+++ b/helm/controller/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - --leader-elect
             - --health-probe-bind-address=:8081
-            {{ -if .Values.apiToken }}
+            {{- if .Values.apiToken }}
             - --linode-creds=linode-cfw
             - --linode-creds-ns={{ required ".Values.namespace required" .Values.namespace }}
             {{- end}}

--- a/helm/controller/templates/deployment.yaml
+++ b/helm/controller/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
-  namespace: kube-system
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
   labels:
     {{- include "cloud-firewall-controller.labels" . | nindent 4 }}
 spec:

--- a/helm/controller/templates/deployment.yaml
+++ b/helm/controller/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           args:
             - --leader-elect
             - --health-probe-bind-address=:8081
+            {{ -if .Values.apiToken }}
+            - --linode-creds=linode-cfw
+            - --linode-creds-ns={{ required ".Values.namespace required" .Values.namespace }}
+            {{- end}}
           command:
             - /manager
           securityContext:

--- a/helm/controller/templates/rbac/ctrl-cluster-rolebinding.yaml
+++ b/helm/controller/templates/rbac/ctrl-cluster-rolebinding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cloud-firewall-controller
-  namespace: kube-system
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}

--- a/helm/controller/templates/rbac/ctrl-role.yml
+++ b/helm/controller/templates/rbac/ctrl-role.yml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cloud-firewall-controller
-  namespace: kube-system
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-weight": "-5"

--- a/helm/controller/templates/rbac/ctrl-rolebinding.yaml
+++ b/helm/controller/templates/rbac/ctrl-rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-weight": "-5"
   name: cloud-firewall-controller
-  namespace: kube-system
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cloud-firewall-controller
-  namespace: kube-system
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}

--- a/helm/controller/templates/serviceaccount.yaml
+++ b/helm/controller/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}
-  namespace: kube-system
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
   labels:
     {{- include "cloud-firewall-controller.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount -}}

--- a/helm/controller/values.yaml
+++ b/helm/controller/values.yaml
@@ -1,6 +1,8 @@
 # Default values for cloud-firewall-controller.
 replicaCount: 1
 
+namespace: "kube-system"
+
 image:
   repository: docker.io/hwagner/cloud-firewall-controller
   pullPolicy: IfNotPresent

--- a/secret.yaml
+++ b/secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.apiToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linode-cfw
+  namespace: {{ required ".Values.namespace required" .Values.namespace }}
+stringData:
+  token: {{ required ".Values.apiToken required" .Values.apiToken }}
+type: Opaque
+{{- end }}


### PR DESCRIPTION
In order to support importing a predefined/shared firewall the controller must be able to access firewall objects through the Linode API that are outside the scope of the cluster. This means that using the token provided by the CCM is insufficient for this purpose.

These changes take the first step by allowing the user to import an API token that can be used. The token only needs to be created with only Firewall (i.e. Cloud Firewall) Read/Write permissions. Any permissions beyond that will be superfluous. 